### PR TITLE
Uat

### DIFF
--- a/packages/frontend/src/app/(dashboard)/dashboard/performance-overview/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/dashboard/performance-overview/page.tsx
@@ -467,7 +467,7 @@ export default function PerformanceOverviewPage() {
               <Button
                 variant="outline"
                 className="h-full flex flex-col items-center justify-center gap-2"
-                onClick={() => router.push('/dashboard/signals')}
+                onClick={() => router.push('/dashboard/trade-signals')}
               >
                 <TrendingUp className="h-5 w-5" />
                 <span>Trading Signals</span>

--- a/packages/frontend/src/features/agents/components/create-agent-dialog/create-agent-dialog.tsx
+++ b/packages/frontend/src/features/agents/components/create-agent-dialog/create-agent-dialog.tsx
@@ -166,13 +166,14 @@ export function CreateAgentDialog({
         message="create"
       />
       <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="shrink-0 px-6 pt-6 pb-4">
           <DialogTitle>Create New Agent</DialogTitle>
           <DialogDescription>
             Create your own AI agent with a unique name.
           </DialogDescription>
         </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 pb-6">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <FormField
@@ -327,6 +328,7 @@ export function CreateAgentDialog({
             </div>
           </form>
         </Form>
+        </div>
       </DialogContent>
     </Dialog>
     </>


### PR DESCRIPTION
fix(frontend): signals link, dev CSP, and create-agent modal on small screens
Correct performance overview Trading Signals quick link to /dashboard/trade-signals. Allow backend API origin in CSP connect-src for development (fixes blocked fetch to localhost:4000). Make create-agent dialog scrollable with max-h and overflow so actions are reachable on small screens.