### PR TITLE
fix: remove admin password restriction and truncate long agent names …

### DIFF
--- a/packages/backend/env.example
+++ b/packages/backend/env.example
@@ -10,7 +10,7 @@ JWT_SECRET="your-secret-here-minimum-32-characters"
 # Admin account credentials (required)
 # The admin account is created automatically on first boot.
 # Registration is disabled — this is the only way to create a user.
-# Password must be 8+ chars with uppercase, lowercase, number, and special character.
+# No password format is enforced (any non-empty value is accepted).
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=YourSecurePassword1!
 

--- a/packages/backend/src/infrastructure/database/seed-admin.ts
+++ b/packages/backend/src/infrastructure/database/seed-admin.ts
@@ -13,16 +13,14 @@
  */
 
 import { prisma } from './client.js';
-import {
-  hashPassword,
-  verifyPassword,
-  validatePasswordStrength,
-} from '@/shared/utils/auth/password.js';
+import { hashPassword, verifyPassword } from '@/shared/utils/auth/password.js';
 
 /**
  * Validates ADMIN_EMAIL and ADMIN_PASSWORD env vars and returns them.
+ * No password strength rules are enforced so deployment platforms (e.g. Railway)
+ * can accept any value the user sets without causing startup failure.
  *
- * @throws Error if env vars are missing or invalid
+ * @throws Error if env vars are missing or email is invalid
  * @returns Validated email and password
  */
 function getValidatedAdminCredentials(): { email: string; password: string } {
@@ -39,14 +37,6 @@ function getValidatedAdminCredentials(): { email: string; password: string } {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email)) {
     throw new Error(`ADMIN_EMAIL "${email}" is not a valid email address.`);
-  }
-
-  const strength = validatePasswordStrength(password);
-  if (!strength.valid) {
-    throw new Error(
-      'ADMIN_PASSWORD does not meet strength requirements: ' +
-        strength.errors.join('; ')
-    );
   }
 
   return { email, password };

--- a/packages/frontend/src/app/(dashboard)/dashboard/general/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/dashboard/general/page.tsx
@@ -146,8 +146,8 @@ export default function GeneralPage() {
                             <Bot className="h-5 w-5" />
                           </AvatarFallback>
                         </Avatar>
-                        <div className="flex-1 space-y-1">
-                          <p className="text-sm font-medium leading-none">
+                        <div className="flex-1 space-y-1 min-w-0 overflow-hidden">
+                          <p className="text-sm font-medium leading-none truncate" title={agent.name || undefined}>
                             {agent.name || 'Unnamed Agent'}
                           </p>
                           <div className="flex items-center gap-2">

--- a/packages/frontend/src/features/agents/components/agent-switcher/agent-switcher.tsx
+++ b/packages/frontend/src/features/agents/components/agent-switcher/agent-switcher.tsx
@@ -77,13 +77,13 @@ function AgentSwitcherComponent({ className }: AgentSwitcherProps) {
           className={cn("w-full justify-between px-4 py-6", className)}
           disabled={agents.length === 0 && !isLoading}
         >
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 min-w-0 flex-1">
             {renderLogo()}
-            <div className="flex flex-col items-start">
-              <span className="text-sm font-medium">
+            <div className="flex flex-col items-start min-w-0 flex-1 overflow-hidden">
+              <span className="text-sm font-medium truncate w-full" title={selectedAgent?.name}>
                 {selectedAgent?.name || 'No agents found'}
               </span>
-              <span className="text-xs text-muted-foreground">
+              <span className="text-xs text-muted-foreground truncate w-full">
                 {agents.length === 0 && !isLoading ? "Create an agent to start" : "Click to swap agent"}
               </span>
             </div>
@@ -102,17 +102,19 @@ function AgentSwitcherComponent({ className }: AgentSwitcherProps) {
               <Button
                 key={agent.id}
                 variant="ghost"
-                className="w-full justify-start gap-2"
+                className="w-full justify-start gap-2 min-w-0"
                 onClick={() => handleAgentSelect(agent)}
               >
                 {renderLogo()}
-                <div className="flex flex-col items-start flex-1">
-                  <div className="flex items-center justify-between w-full gap-2">
-                    <span className="text-sm">{agent.name}</span>
+                <div className="flex flex-col items-start flex-1 min-w-0 overflow-hidden">
+                  <div className="flex items-center justify-between w-full gap-2 min-w-0">
+                    <span className="text-sm truncate" title={agent.name}>
+                      {agent.name}
+                    </span>
                   </div>
                 </div>
                 {selectedAgentId === agent.id && (
-                  <Check className="ml-auto h-4 w-4" />
+                  <Check className="ml-auto h-4 w-4 shrink-0" />
                 )}
               </Button>
             ))


### PR DESCRIPTION
…in UI

- Remove ADMIN_PASSWORD strength validation in seed-admin so deployments (e.g. Railway) accept any non-empty password and server starts reliably.
- Update env.example to state no password format is enforced.
- Truncate agent names in sidebar switcher and general page with ellipsis and title tooltip so long names do not break layout.

Fixes #19