### PR TITLE
fix(frontend): enforce 0.05 SOL minimum and max >= min on position sizes

### DIFF
--- a/packages/frontend/src/features/agents/components/agent-profile/PurchaseAndPositionSection.tsx
+++ b/packages/frontend/src/features/agents/components/agent-profile/PurchaseAndPositionSection.tsx
@@ -137,7 +137,8 @@ function CategoryRow({
   rangeLabel: string;
 }) {
   const { errors } = form.formState;
-  const sizeErrorMessage = errors.positionCalculator?.positionSizes?.[category]?.message;
+  const categoryErrors = errors.positionCalculator?.positionSizes?.[category];
+  const sizeErrorMessage = categoryErrors?.message ?? categoryErrors?.root?.message;
 
   return (
     <div className="grid gap-4 md:grid-cols-3 border rounded-lg p-4 items-center">

--- a/packages/shared/src/constants/trading-config-defaults.ts
+++ b/packages/shared/src/constants/trading-config-defaults.ts
@@ -8,6 +8,9 @@
 
 import type { AgentTradingConfig, AutoTradeConfig, DCAConfig, SignalConfig, TakeProfitConfig } from '../types/trading-config.js';
 
+/** Hard minimum position size in SOL — prevents dust-sized trades. */
+export const MINIMUM_POSITION_SIZE_SOL = 0.05;
+
 /**
  * Common signal types for dropdown selection
  * These are predefined options available in the UI

--- a/packages/shared/src/types/trading-config-validation.ts
+++ b/packages/shared/src/types/trading-config-validation.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import { MINIMUM_POSITION_SIZE_SOL } from '../constants/trading-config-defaults.js';
 
 /**
  * Trailing level validation schema
@@ -81,16 +82,17 @@ export const purchaseLimitsSchema = z.object({
 });
 
 /**
- * Position size range validation schema
+ * Position size range validation schema.
+ * Enforces a hard floor of MINIMUM_POSITION_SIZE_SOL to prevent dust-sized trades.
  */
 export const positionSizeRangeSchema = z.object({
   min: z.number()
-    .nonnegative('Minimum position size must be >= 0'),
+    .min(MINIMUM_POSITION_SIZE_SOL, `Minimum purchase size is ${MINIMUM_POSITION_SIZE_SOL} SOL`),
   max: z.number()
-    .nonnegative('Maximum position size must be >= 0'),
+    .min(MINIMUM_POSITION_SIZE_SOL, `Minimum purchase size is ${MINIMUM_POSITION_SIZE_SOL} SOL`),
 }).refine(
   (data) => data.min <= data.max,
-  { message: 'Minimum position size must be <= maximum position size' }
+  { message: 'Max must be greater than or equal to min', path: ['max'] }
 );
 
 /**


### PR DESCRIPTION
- Add MINIMUM_POSITION_SIZE_SOL (0.05) in shared constants
- Validate position size min/max with 0.05 SOL floor in Zod schema
- Route refine error to max field so FormMessage shows under input
- Fallback to root.message for object-level errors in CategoryRow