### PR TITLE
Uat

### DIFF
--- a/packages/backend/src/api/v1/agents/handlers/config/update.ts
+++ b/packages/backend/src/api/v1/agents/handlers/config/update.ts
@@ -20,13 +20,16 @@ import {
   AUTO_TRADE_SIGNAL_TYPE,
   AUTO_TRADE_SIGNAL_SOURCE,
 } from '@/domain/trading/auto-trade-constants.js';
+import { evaluateAutoTradeMarketCapGuard } from '@/domain/trading/auto-trade-market-cap-guard.js';
 import type { AgentTradingConfig } from '@nexgent/shared';
 
-/** Minimal token shape returned by {@link getImmediateAutoTradeTokens}. */
+/** Token shape returned by {@link getImmediateAutoTradeTokens}, includes market-cap bounds. */
 type AutoTradeToken = {
   address: string;
   symbol?: string;
   enabled: boolean;
+  marketCapMin?: number;
+  marketCapMax?: number;
 };
 
 /**
@@ -182,6 +185,27 @@ export async function updateAgentTradingConfig(req: AuthenticatedRequest, res: R
 
       for (const token of immediateTokens) {
         try {
+          // Enforce per-token market-cap bounds before immediate purchase.
+          // If out of range, the 30s market-cap monitor will pick it up later.
+          const marketCapGuard = await evaluateAutoTradeMarketCapGuard({
+            tokenAddress: token.address.trim(),
+            tokenBounds: { marketCapMin: token.marketCapMin, marketCapMax: token.marketCapMax },
+          });
+          if (!marketCapGuard.allowed) {
+            logger.info(
+              {
+                agentId: id,
+                tokenAddress: token.address,
+                reason: marketCapGuard.reason,
+                marketCap: marketCapGuard.marketCap,
+                marketCapMin: token.marketCapMin ?? null,
+                marketCapMax: token.marketCapMax ?? null,
+              },
+              'Auto-trade immediate buy deferred: market-cap out of range, monitor will retry'
+            );
+            continue;
+          }
+
           const signalId = await createImmediateAutoTradeSignal({
             userId: req.user.id,
             tokenAddress: token.address,

--- a/packages/backend/src/domain/trading/auto-trade-market-cap-monitor.service.ts
+++ b/packages/backend/src/domain/trading/auto-trade-market-cap-monitor.service.ts
@@ -1,0 +1,301 @@
+/**
+ * Auto-Trade Market Cap Monitor
+ *
+ * Runs every 30 seconds and monitors auto-trade tokens that are enabled but
+ * don't yet have open positions. When a token's market cap enters its configured
+ * range (or has no bounds), the monitor triggers a purchase.
+ *
+ * This complements the reconciliation manager (10-min safety net) by providing
+ * faster reaction to market cap changes. Tokens with market-cap bounds are
+ * handled exclusively by this monitor; the reconciliation manager skips them.
+ *
+ * All token addresses across agents are batched into a single Jupiter API call
+ * per cycle to avoid rate limiting.
+ */
+
+import { prisma } from '@/infrastructure/database/client.js';
+import { redisAgentService } from '@/infrastructure/cache/redis-agent-service.js';
+import { idempotencyService } from '@/infrastructure/cache/idempotency-service.js';
+import { configService } from './config-service.js';
+import { AgentRepository } from '@/infrastructure/database/repositories/agent.repository.js';
+import { tradingExecutor, TradingExecutorError } from './trading-executor.service.js';
+import { hasAutoTradeMarketCapBounds } from './auto-trade-market-cap-guard.js';
+import { fetchTokenMetricsBatch } from '@/infrastructure/external/jupiter/index.js';
+import type { TokenMetrics } from '@/infrastructure/external/jupiter/index.js';
+import {
+  AUTO_TRADE_SIGNAL_TYPE,
+  AUTO_TRADE_SIGNAL_SOURCE,
+  EXPECTED_AUTO_TRADE_SKIP_CODES,
+} from './auto-trade-constants.js';
+import logger from '@/infrastructure/logging/logger.js';
+
+const MONITOR_INTERVAL_MS = 30_000; // 30 seconds
+const MONITOR_LOCK_TTL_SECONDS = 25; // Shorter than interval to allow re-evaluation
+const MONITOR_IDEMPOTENCY_PREFIX = 'auto-trade-mcap-monitor';
+
+/** A token that needs market-cap monitoring before auto-trade purchase. */
+interface MonitoredToken {
+  agentId: string;
+  walletAddress: string;
+  tokenAddress: string;
+  originalTokenAddress: string;
+  tokenSymbol?: string;
+  marketCapMin?: number;
+  marketCapMax?: number;
+}
+
+/**
+ * Create a synthetic signal record for monitor-triggered purchases.
+ *
+ * Preserves the signal → position linkage used by DCA/take-profit history.
+ */
+async function createMonitorAutoTradeSignal(params: {
+  agentId: string;
+  tokenAddress: string;
+  tokenSymbol?: string;
+}): Promise<number | null> {
+  try {
+    const agent = await prisma.agent.findUnique({
+      where: { id: params.agentId },
+      select: { userId: true },
+    });
+    if (!agent) return null;
+
+    const signal = await prisma.tradingSignal.create({
+      data: {
+        tokenAddress: params.tokenAddress.trim(),
+        symbol: params.tokenSymbol?.trim() || null,
+        signalType: AUTO_TRADE_SIGNAL_TYPE,
+        activationReason: 'Auto-trade market-cap monitor entry',
+        signalStrength: 3,
+        source: AUTO_TRADE_SIGNAL_SOURCE,
+        userId: agent.userId,
+      },
+    });
+    return signal.id;
+  } catch (error) {
+    logger.warn(
+      { agentId: params.agentId, tokenAddress: params.tokenAddress, error: error instanceof Error ? error.message : String(error) },
+      'Auto-trade monitor signal creation failed; continuing without signal link'
+    );
+    return null;
+  }
+}
+
+/**
+ * Background service that monitors auto-trade tokens awaiting market-cap entry.
+ */
+class AutoTradeMarketCapMonitor {
+  private interval: NodeJS.Timeout | null = null;
+  private readonly agentRepo = new AgentRepository();
+
+  /** Start the monitor loop (idempotent). */
+  initialize(): void {
+    if (this.interval) return;
+
+    this.interval = setInterval(() => {
+      this.runCycle().catch((error) => {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          'Auto-trade market-cap monitor cycle failed'
+        );
+      });
+    }, MONITOR_INTERVAL_MS);
+
+    logger.info({ intervalMs: MONITOR_INTERVAL_MS }, 'Auto-trade market-cap monitor initialized');
+  }
+
+  /** Stop the monitor loop for clean shutdown. */
+  shutdown(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+      logger.info('Auto-trade market-cap monitor shut down');
+    }
+  }
+
+  /** Run one full monitoring cycle across all active agents. */
+  private async runCycle(): Promise<void> {
+    const monitored = await this.collectMonitoredTokens();
+    if (monitored.length === 0) return;
+
+    // Deduplicate token addresses for a single batch API call
+    const uniqueAddresses = [...new Set(monitored.map((t) => t.originalTokenAddress))];
+
+    const metricsMap = await fetchTokenMetricsBatch(uniqueAddresses);
+
+    logger.debug(
+      { monitoredCount: monitored.length, uniqueTokens: uniqueAddresses.length },
+      'Auto-trade market-cap monitor cycle running'
+    );
+
+    for (const token of monitored) {
+      await this.evaluateAndExecute(token, metricsMap);
+    }
+  }
+
+  /**
+   * Collect all auto-trade tokens across active agents that are enabled but
+   * don't have an open position. These are the tokens that need monitoring.
+   */
+  private async collectMonitoredTokens(): Promise<MonitoredToken[]> {
+    const activeAgentIds = await redisAgentService.getActiveAgentIds();
+    if (activeAgentIds.length === 0) return [];
+
+    const monitored: MonitoredToken[] = [];
+
+    for (const agentId of activeAgentIds) {
+      try {
+        const config = await configService.loadAgentConfig(agentId);
+        if (!config.autoTrade?.enabled) continue;
+
+        const enabledTokens = (config.autoTrade.tokens ?? []).filter((t) => t.enabled);
+        if (enabledTokens.length === 0) continue;
+
+        const tradingMode = await redisAgentService.getTradingMode(agentId);
+        const wallet = await this.agentRepo.findWalletByAgentId(agentId, tradingMode);
+        if (!wallet?.walletAddress) continue;
+
+        // Find which enabled tokens already have an open position
+        const existingPositions = await prisma.agentPosition.findMany({
+          where: {
+            agentId,
+            walletAddress: wallet.walletAddress,
+            tokenAddress: {
+              in: enabledTokens.map((t) => t.address.trim().toLowerCase()),
+              mode: 'insensitive',
+            },
+          },
+          select: { tokenAddress: true },
+        });
+        const positionTokens = new Set(existingPositions.map((p) => p.tokenAddress.toLowerCase()));
+
+        for (const token of enabledTokens) {
+          const normalized = token.address.trim().toLowerCase();
+          if (positionTokens.has(normalized)) continue;
+
+          monitored.push({
+            agentId,
+            walletAddress: wallet.walletAddress,
+            tokenAddress: normalized,
+            originalTokenAddress: token.address.trim(),
+            tokenSymbol: token.symbol,
+            marketCapMin: token.marketCapMin,
+            marketCapMax: token.marketCapMax,
+          });
+        }
+      } catch (error) {
+        logger.warn(
+          { agentId, error: error instanceof Error ? error.message : String(error) },
+          'Auto-trade market-cap monitor skipped agent due to error'
+        );
+      }
+    }
+
+    return monitored;
+  }
+
+  /**
+   * Evaluate a single monitored token against its market-cap bounds and
+   * execute a purchase if conditions are met.
+   */
+  private async evaluateAndExecute(
+    token: MonitoredToken,
+    metricsMap: Map<string, TokenMetrics | null>,
+  ): Promise<void> {
+    const { agentId, walletAddress, tokenAddress, originalTokenAddress, tokenSymbol, marketCapMin, marketCapMax } = token;
+    const idempotencyKey = `${MONITOR_IDEMPOTENCY_PREFIX}:${agentId}:${tokenAddress}`;
+
+    const canProceed = await idempotencyService.checkAndSet(idempotencyKey, MONITOR_LOCK_TTL_SECONDS);
+    if (!canProceed) return;
+
+    const hasBounds = hasAutoTradeMarketCapBounds({ marketCapMin, marketCapMax });
+
+    if (hasBounds) {
+      const metrics = metricsMap.get(originalTokenAddress);
+      const marketCap = metrics?.mcap ?? null;
+
+      // Fail-closed: if bounds are set but metrics are unavailable, skip
+      if (marketCap == null) {
+        logger.debug(
+          { agentId, tokenAddress, reason: 'market_cap_unavailable' },
+          'Auto-trade monitor skipped: metrics unavailable'
+        );
+        return;
+      }
+
+      if (marketCapMin != null && marketCap < marketCapMin) {
+        logger.debug(
+          { agentId, tokenAddress, marketCap, marketCapMin },
+          'Auto-trade monitor: market cap below min, will retry next cycle'
+        );
+        return;
+      }
+
+      if (marketCapMax != null && marketCap > marketCapMax) {
+        logger.debug(
+          { agentId, tokenAddress, marketCap, marketCapMax },
+          'Auto-trade monitor: market cap above max, will retry next cycle'
+        );
+        return;
+      }
+
+      logger.info(
+        { agentId, tokenAddress, marketCap, marketCapMin: marketCapMin ?? null, marketCapMax: marketCapMax ?? null },
+        'Auto-trade monitor: market cap in range, executing purchase'
+      );
+    }
+
+    try {
+      const signalId = await createMonitorAutoTradeSignal({
+        agentId,
+        tokenAddress: originalTokenAddress,
+        tokenSymbol,
+      });
+
+      const result = await tradingExecutor.executePurchase({
+        agentId,
+        walletAddress,
+        tokenAddress: originalTokenAddress,
+        tokenSymbol: tokenSymbol?.trim() || undefined,
+        signalId: signalId ?? undefined,
+      });
+
+      logger.info(
+        {
+          agentId,
+          walletAddress,
+          tokenAddress,
+          transactionId: result.transactionId,
+          positionId: result.positionId,
+        },
+        'Auto-trade monitor opened position'
+      );
+    } catch (error) {
+      if (error instanceof TradingExecutorError && error.code && EXPECTED_AUTO_TRADE_SKIP_CODES.has(error.code)) {
+        logger.info(
+          { agentId, tokenAddress, code: error.code, reason: error.message },
+          'Auto-trade monitor purchase skipped by execution guardrail'
+        );
+        return;
+      }
+
+      logger.warn(
+        { agentId, tokenAddress, error: error instanceof Error ? error.message : String(error) },
+        'Auto-trade monitor failed to open position'
+      );
+    }
+  }
+}
+
+const autoTradeMarketCapMonitor = new AutoTradeMarketCapMonitor();
+
+/** Start the market-cap monitor. Called once at app bootstrap. */
+export function initializeAutoTradeMarketCapMonitor(): void {
+  autoTradeMarketCapMonitor.initialize();
+}
+
+/** Stop the market-cap monitor for clean process exit. */
+export function shutdownAutoTradeMarketCapMonitor(): void {
+  autoTradeMarketCapMonitor.shutdown();
+}

--- a/packages/backend/src/domain/trading/auto-trade-reconciliation-manager.service.ts
+++ b/packages/backend/src/domain/trading/auto-trade-reconciliation-manager.service.ts
@@ -4,6 +4,10 @@
  * Periodically verifies that enabled auto-trade tokens have active positions.
  * If a token is enabled for auto-trade but no open position exists, this manager
  * attempts to open one (subject to market-cap policy and normal trade guardrails).
+ *
+ * Tokens with per-token market-cap bounds are skipped here and handled by the
+ * faster-cadence AutoTradeMarketCapMonitor (30s). This manager acts as a 10-min
+ * safety net for tokens without bounds.
  */
 
 import { prisma } from '@/infrastructure/database/client.js';
@@ -12,7 +16,7 @@ import { idempotencyService } from '@/infrastructure/cache/idempotency-service.j
 import { configService } from './config-service.js';
 import { AgentRepository } from '@/infrastructure/database/repositories/agent.repository.js';
 import { tradingExecutor, TradingExecutorError } from './trading-executor.service.js';
-import { evaluateAutoTradeMarketCapGuard } from './auto-trade-market-cap-guard.js';
+import { evaluateAutoTradeMarketCapGuard, hasAutoTradeMarketCapBounds } from './auto-trade-market-cap-guard.js';
 import type { TokenMarketCapBounds } from './auto-trade-market-cap-guard.js';
 import { EXPECTED_AUTO_TRADE_SKIP_CODES } from './auto-trade-constants.js';
 import logger from '@/infrastructure/logging/logger.js';
@@ -94,6 +98,10 @@ export class AutoTradeReconciliationManager {
       }
 
       for (const token of enabledTokens) {
+        // Tokens with market-cap bounds are handled by the 30s market-cap monitor.
+        // Reconciliation only covers tokens without bounds as a 10-min safety net.
+        if (hasAutoTradeMarketCapBounds(token)) continue;
+
         await this.reconcileToken({
           agentId,
           walletAddress: wallet.walletAddress,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -116,6 +116,7 @@ import { wsServer } from './infrastructure/websocket/server.js';
 import { priceUpdateManager } from './domain/prices/index.js';
 import { initializeAutoTradeReentryManager, shutdownAutoTradeReentryManager } from './domain/trading/auto-trade-reentry-manager.service.js';
 import { initializeAutoTradeReconciliationManager, shutdownAutoTradeReconciliationManager } from './domain/trading/auto-trade-reconciliation-manager.service.js';
+import { initializeAutoTradeMarketCapMonitor, shutdownAutoTradeMarketCapMonitor } from './domain/trading/auto-trade-market-cap-monitor.service.js';
 import type { Server } from 'http';
 import { errorHandler, notFoundHandler } from '@/middleware/error-handler.js';
 import { requestLogger } from '@/middleware/request-logger.js';
@@ -320,6 +321,7 @@ async function startServer() {
       // Initialize auto-trade re-entry manager
       initializeAutoTradeReentryManager();
       initializeAutoTradeReconciliationManager();
+      initializeAutoTradeMarketCapMonitor();
 
       // Initialize price update manager (after WebSocket server)
       priceUpdateManager.initialize(wsServer);
@@ -403,6 +405,7 @@ function setupGracefulShutdown() {
       try {
         shutdownAutoTradeReentryManager();
         shutdownAutoTradeReconciliationManager();
+        shutdownAutoTradeMarketCapMonitor();
       } catch (error) {
         console.error('❌ Error shutting down auto-trade managers:', error);
       }

--- a/packages/backend/src/infrastructure/external/jupiter/index.ts
+++ b/packages/backend/src/infrastructure/external/jupiter/index.ts
@@ -11,9 +11,10 @@ export * from './jupiter-swap-provider.js';
 // Price functionality
 export * from './price/index.js';
 
-// Token metrics (signal pre-check)
+// Token metrics (signal pre-check + auto-trade monitoring)
 export {
   fetchTokenMetrics,
+  fetchTokenMetricsBatch,
   clearTokenMetricsCache,
   type TokenMetrics,
 } from './jupiter-token-metrics.service.js';

--- a/packages/backend/src/infrastructure/external/jupiter/jupiter-token-metrics.service.ts
+++ b/packages/backend/src/infrastructure/external/jupiter/jupiter-token-metrics.service.ts
@@ -121,6 +121,133 @@ export async function fetchTokenMetrics(tokenAddress: string): Promise<TokenMetr
   }
 }
 
+/**
+ * Fetch token metrics for multiple mint addresses in a single API call.
+ *
+ * Jupiter Tokens API v2 search supports comma-separated addresses (up to 100
+ * per request). Addresses already in the in-memory cache are served from cache;
+ * only uncached addresses hit the API. If more than 100 uncached addresses are
+ * provided, they are chunked into sequential requests.
+ *
+ * @see https://dev.jup.ag/docs/tokens/v2/token-information
+ * @param tokenAddresses - Array of Solana token mint addresses
+ * @returns Map of tokenAddress → TokenMetrics (or null if unavailable)
+ */
+export async function fetchTokenMetricsBatch(
+  tokenAddresses: string[],
+): Promise<Map<string, TokenMetrics | null>> {
+  const results = new Map<string, TokenMetrics | null>();
+  const uncached: string[] = [];
+
+  const deduplicated = [...new Set(tokenAddresses)];
+
+  for (const addr of deduplicated) {
+    const cached = metricsCache.get(addr);
+    if (cached && Date.now() < cached.expiresAt) {
+      results.set(addr, cached.metrics);
+    } else {
+      uncached.push(addr);
+    }
+  }
+
+  if (uncached.length === 0) {
+    return results;
+  }
+
+  const apiKey = getJupiterApiKey();
+  if (!apiKey) {
+    logger.warn('[JupiterTokenMetrics] JUPITER_API_KEY not set; skipping batch token metrics fetch');
+    for (const addr of uncached) {
+      results.set(addr, null);
+    }
+    return results;
+  }
+
+  const CHUNK_SIZE = 100;
+  for (let i = 0; i < uncached.length; i += CHUNK_SIZE) {
+    const chunk = uncached.slice(i, i + CHUNK_SIZE);
+    const queryValue = chunk.join(',');
+    const url = `${JUPITER_TOKENS_V2_SEARCH_URL}?query=${encodeURIComponent(queryValue)}`;
+
+    try {
+      const response = await withTimeout(
+        fetch(url, {
+          method: 'GET',
+          headers: {
+            'x-api-key': apiKey,
+            'Content-Type': 'application/json',
+          },
+        }),
+        TOKEN_METRICS_TIMEOUT_MS,
+        `Jupiter batch token metrics request timed out (${chunk.length} tokens)`
+      );
+
+      if (!response.ok) {
+        const text = await response.text();
+        logger.warn(
+          { tokenCount: chunk.length, status: response.status, body: text.slice(0, 200) },
+          '[JupiterTokenMetrics] Batch API error'
+        );
+        for (const addr of chunk) {
+          cacheResult(addr, null);
+          results.set(addr, null);
+        }
+        continue;
+      }
+
+      const data = (await response.json()) as JupiterMintInformation[];
+      if (!Array.isArray(data)) {
+        logger.warn({ tokenCount: chunk.length }, '[JupiterTokenMetrics] Unexpected batch response format');
+        for (const addr of chunk) {
+          cacheResult(addr, null);
+          results.set(addr, null);
+        }
+        continue;
+      }
+
+      // Index response items by their `id` (mint address) for O(1) lookup
+      const responseById = new Map<string, JupiterMintInformation>();
+      for (const item of data) {
+        if (item.id) {
+          responseById.set(item.id, item);
+        }
+      }
+
+      for (const addr of chunk) {
+        const item = responseById.get(addr);
+        if (item) {
+          const metrics: TokenMetrics = {
+            mcap: item.mcap ?? null,
+            liquidity: item.liquidity ?? null,
+            holderCount: item.holderCount ?? null,
+          };
+          cacheResult(addr, metrics);
+          results.set(addr, metrics);
+        } else {
+          cacheResult(addr, null);
+          results.set(addr, null);
+        }
+      }
+
+      logger.debug(
+        { requested: chunk.length, returned: data.length },
+        '[JupiterTokenMetrics] Batch fetch completed'
+      );
+    } catch (error) {
+      logger.warn(
+        { tokenCount: chunk.length, error: error instanceof Error ? error.message : String(error) },
+        '[JupiterTokenMetrics] Batch fetch failed'
+      );
+      for (const addr of chunk) {
+        cacheResult(addr, null);
+        results.set(addr, null);
+      }
+    }
+  }
+
+  return results;
+}
+
 /** Store a result in the cache with the configured TTL. */
 function cacheResult(tokenAddress: string, metrics: TokenMetrics | null): void {
   metricsCache.set(tokenAddress, {

--- a/packages/backend/tests/unit/domain/trading/auto-trade-reconciliation-manager.service.test.ts
+++ b/packages/backend/tests/unit/domain/trading/auto-trade-reconciliation-manager.service.test.ts
@@ -44,6 +44,9 @@ jest.mock('@/infrastructure/database/repositories/agent.repository.js', () => ({
 
 jest.mock('@/domain/trading/auto-trade-market-cap-guard.js', () => ({
   evaluateAutoTradeMarketCapGuard: jest.fn(),
+  hasAutoTradeMarketCapBounds: jest.fn((token: { marketCapMin?: number; marketCapMax?: number }) =>
+    token.marketCapMin != null || token.marketCapMax != null
+  ),
 }));
 
 jest.mock('@/domain/trading/trading-executor.service.js', () => ({
@@ -91,6 +94,8 @@ describe('AutoTradeReconciliationManager', () => {
     mockRedisAgentService.getActiveAgentIds.mockResolvedValue(['agent-1']);
     mockRedisAgentService.getTradingMode.mockResolvedValue('simulation');
     mockIdempotencyService.checkAndSet.mockResolvedValue(true);
+    // Token without market-cap bounds so reconciliation processes it (tokens with bounds
+    // are handled by the 30s market-cap monitor and skipped here).
     mockConfigService.loadAgentConfig.mockResolvedValue({
       autoTrade: {
         enabled: true,
@@ -98,8 +103,6 @@ describe('AutoTradeReconciliationManager', () => {
           address: 'Token111111111111111111111111111111111111',
           symbol: 'TKN',
           enabled: true,
-          marketCapMin: 200_000,
-          marketCapMax: 5_000_000,
         }],
       },
     });

--- a/packages/frontend/src/features/agents/components/agent-profile/AutoTradeSection.tsx
+++ b/packages/frontend/src/features/agents/components/agent-profile/AutoTradeSection.tsx
@@ -24,8 +24,9 @@ import { Button } from '@/shared/components/ui/button';
 import { Separator } from '@/shared/components/ui/separator';
 import { Alert, AlertDescription } from '@/shared/components/ui/alert';
 import { useFormContext } from 'react-hook-form';
-import { RefreshCw, X, Loader2, Info, Coins } from 'lucide-react';
+import { RefreshCw, X, Loader2, Info, Coins, Radio, CircleCheck } from 'lucide-react';
 import { useTokenMetadata } from '@/features/agents/hooks/use-token-metadata';
+import { useAutoTradePositionTokens } from '@/features/agents/hooks/use-auto-trade-position-tokens';
 import type { AgentTradingConfigFormValues } from './trading-config-form-schema';
 import { cn } from '@/shared/utils/cn';
 
@@ -41,10 +42,27 @@ function formatAddress(address: string): string {
   return `${address.slice(0, 6)}...${address.slice(-6)}`;
 }
 
+interface AutoTradeSectionProps {
+  agentId: string;
+}
+
+/** Derive the monitoring status for an enabled auto-trade token. */
+function getTokenStatus(
+  tokenEnabled: boolean,
+  globalEnabled: boolean,
+  hasPosition: boolean,
+  hasBounds: boolean,
+): 'disabled' | 'active' | 'monitoring' | 'waiting_for_range' {
+  if (!tokenEnabled || !globalEnabled) return 'disabled';
+  if (hasPosition) return 'active';
+  return hasBounds ? 'waiting_for_range' : 'monitoring';
+}
+
 /** Auto Trade token list and per-token market-cap configuration. */
-export function AutoTradeSection() {
+export function AutoTradeSection({ agentId }: AutoTradeSectionProps) {
   const form = useFormContext<AgentTradingConfigFormValues>();
   const { fetchTokenMetadata } = useTokenMetadata();
+  const positionTokens = useAutoTradePositionTokens(agentId);
   const enabled = form.watch('autoTrade.enabled') ?? false;
   const tokens = form.watch('autoTrade.tokens') ?? [];
   const [newToken, setNewToken] = useState('');
@@ -101,7 +119,7 @@ export function AutoTradeSection() {
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <CardTitle className="flex items-center gap-2">
               <RefreshCw className="h-5 w-5" />
@@ -142,7 +160,7 @@ export function AutoTradeSection() {
           render={() => (
             <FormItem className="space-y-4">
               <FormLabel>Tokens</FormLabel>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
                 <Input
                   placeholder="Token mint address (e.g. ...pump)"
                   value={newToken}
@@ -156,12 +174,12 @@ export function AutoTradeSection() {
                       if (!isResolvingSymbol) void addToken();
                     }
                   }}
-                  className="font-mono text-sm"
+                  className="font-mono text-sm w-full sm:flex-1"
                 />
                 <Button
                   type="button"
                   variant="secondary"
-                  className="min-w-[88px] h-10"
+                  className="w-full sm:min-w-[88px] sm:w-auto h-10"
                   onClick={() => void addToken()}
                   aria-label="Add token address"
                   disabled={isResolvingSymbol}
@@ -183,13 +201,18 @@ export function AutoTradeSection() {
               <Alert className="bg-muted/40">
                 <Info className="h-4 w-4" />
                 <AlertDescription className="text-sm">
-                  Each token has optional market cap bounds. Re-entry and DCA buys will only execute while the token's market cap is within the configured range. Leave empty for no restriction.
+                  Each token has optional market cap bounds. Auto-trade purchases, re-entry, and DCA buys will only execute while the token's market cap is within the configured range. Tokens with bounds are monitored every 30 seconds. Leave empty for no restriction.
                 </AlertDescription>
               </Alert>
 
               {tokens.length > 0 && (
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
-                  {tokens.map((token: { address: string; symbol?: string; logoUrl?: string; enabled: boolean; marketCapMin?: number; marketCapMax?: number }, index: number) => (
+                  {tokens.map((token: { address: string; symbol?: string; logoUrl?: string; enabled: boolean; marketCapMin?: number; marketCapMax?: number }, index: number) => {
+                    const hasBounds = token.marketCapMin != null || token.marketCapMax != null;
+                    const hasPosition = positionTokens.has(token.address.trim().toLowerCase());
+                    const status = getTokenStatus(token.enabled, enabled, hasPosition, hasBounds);
+
+                    return (
                     <div
                       key={`${token.address}-${index}`}
                       className={cn(
@@ -200,7 +223,7 @@ export function AutoTradeSection() {
                         !enabled && 'opacity-70'
                       )}
                     >
-                      <div className="flex items-center gap-3 p-3">
+                      <div className="flex min-w-0 items-center gap-3 p-3">
                         {token.logoUrl ? (
                           <div className="h-10 w-10 shrink-0 rounded-lg overflow-hidden border border-border/70 bg-muted/30">
                             <img
@@ -236,8 +259,30 @@ export function AutoTradeSection() {
                             {formatAddress(token.address)}
                           </p>
                         </div>
+                      </div>
 
-                        <div className="flex items-center gap-2 ml-1">
+                      <div className="flex items-center justify-between gap-2 px-3 pb-2">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          {status === 'active' && (
+                            <>
+                              <CircleCheck className="h-3.5 w-3.5 shrink-0 text-green-500" />
+                              <span className="text-xs font-medium text-green-600 dark:text-green-400">Active</span>
+                            </>
+                          )}
+                          {status === 'monitoring' && (
+                            <>
+                              <Radio className="h-3.5 w-3.5 shrink-0 text-amber-500 animate-pulse" />
+                              <span className="text-xs font-medium text-amber-600 dark:text-amber-400">Monitoring</span>
+                            </>
+                          )}
+                          {status === 'waiting_for_range' && (
+                            <>
+                              <Radio className="h-3.5 w-3.5 shrink-0 text-amber-500 animate-pulse" />
+                              <span className="text-xs font-medium text-amber-600 dark:text-amber-400">Waiting for range</span>
+                            </>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2 shrink-0">
                           <Switch
                             checked={token.enabled}
                             onCheckedChange={(checked) => toggleToken(index, checked)}
@@ -253,12 +298,10 @@ export function AutoTradeSection() {
                             <X className="h-4 w-4" />
                           </Button>
                         </div>
-
-                        {token.enabled && <span className="absolute top-2 right-2 h-1.5 w-1.5 rounded-full bg-foreground/80" />}
                       </div>
 
                       <div className="border-t px-3 pb-3 pt-2">
-                        <div className="grid grid-cols-2 gap-2">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                           <FormField
                             control={form.control}
                             name={`autoTrade.tokens.${index}.marketCapMin`}
@@ -298,7 +341,8 @@ export function AutoTradeSection() {
                         </div>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
               {tokens.length === 0 && (

--- a/packages/frontend/src/features/agents/components/agent-profile/StrategySection.tsx
+++ b/packages/frontend/src/features/agents/components/agent-profile/StrategySection.tsx
@@ -246,24 +246,24 @@ export function StrategySection({ agentId, agentName, initialConfig }: StrategyS
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <CardTitle>Trading Strategy</CardTitle>
             <CardDescription>
               Configure your agent's trading strategy settings including purchase limits, stop loss, and position sizing.
             </CardDescription>
           </div>
-          <div className="flex items-center gap-3">
-            <Button size="sm" variant="outline" onClick={handleExportConfig} title="Export config to JSON">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+            <Button size="sm" variant="outline" onClick={handleExportConfig} title="Export config to JSON" className="w-full sm:w-auto">
               <Download className="h-4 w-4 mr-1" />
               Export
             </Button>
-            <Button size="sm" variant="outline" onClick={() => setLoadDialogOpen(true)} title="Load config from another agent">
+            <Button size="sm" variant="outline" onClick={() => setLoadDialogOpen(true)} title="Load config from another agent" className="w-full sm:w-auto">
               <FolderInput className="h-4 w-4 mr-1" />
               Load from Agent
             </Button>
             {canSave && (
-              <Button size="sm" onClick={handleSave} disabled={isSaving}>
+              <Button size="sm" onClick={handleSave} disabled={isSaving} className="w-full sm:w-auto">
                 {saveStatus === 'saving' && <LoadingSpinner size="sm" className="mr-1" />}
                 Save Changes
               </Button>
@@ -335,7 +335,7 @@ export function StrategySection({ agentId, agentName, initialConfig }: StrategyS
             {/* Tab Content */}
             <div className="space-y-4 mt-4">
               {activeTab === 'purchase' && <PurchaseAndPositionSection />}
-              {activeTab === 'auto-trade' && <AutoTradeSection />}
+              {activeTab === 'auto-trade' && <AutoTradeSection agentId={agentId} />}
               {activeTab === 'signals' && <SignalsSection />}
               {activeTab === 'risk-management' && <RiskManagementSection />}
               {activeTab === 'stop-loss' && <StopLossSection />}

--- a/packages/frontend/src/features/agents/hooks/use-auto-trade-position-tokens.ts
+++ b/packages/frontend/src/features/agents/hooks/use-auto-trade-position-tokens.ts
@@ -1,0 +1,32 @@
+/**
+ * Hook that returns the set of token addresses with open positions for an agent.
+ *
+ * Used by AutoTradeSection to derive monitoring state: a token that is enabled
+ * for auto-trade but absent from this set is "waiting" / "monitoring".
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { AgentsService } from '@/infrastructure/api/services/agents.service';
+
+const agentsService = new AgentsService();
+
+/**
+ * Fetch open position token addresses for an agent.
+ *
+ * @param agentId - Agent ID (skip query when undefined)
+ * @returns Set of normalized (lowercase) token addresses with open positions
+ */
+export function useAutoTradePositionTokens(agentId: string | undefined): Set<string> {
+  const { data } = useQuery({
+    queryKey: ['autoTradePositionTokens', agentId],
+    queryFn: async () => {
+      const positions = await agentsService.getPositions(agentId!);
+      return positions.map((p) => (p.tokenAddress as string).toLowerCase());
+    },
+    enabled: !!agentId,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
+
+  return new Set(data ?? []);
+}

--- a/packages/frontend/src/features/agents/index.ts
+++ b/packages/frontend/src/features/agents/index.ts
@@ -28,6 +28,7 @@ export {
 } from './hooks/use-agent-trading-config';
 export { useAgentPerformance } from './hooks/use-agent-performance';
 export { useAgentBalanceHistory } from './hooks/use-agent-balance-history';
+export { useAutoTradePositionTokens } from './hooks/use-auto-trade-position-tokens';
 
 // Types
 export type {

--- a/packages/frontend/src/infrastructure/api/services/agents.service.ts
+++ b/packages/frontend/src/infrastructure/api/services/agents.service.ts
@@ -254,6 +254,25 @@ export class AgentsService {
    * const balanceHistory = await agentsService.getAgentBalanceHistory('agent-123', 'wallet-address', 'all');
    * ```
    */
+  /**
+   * Fetch open positions for an agent.
+   *
+   * @param agentId - Agent ID
+   * @returns Promise resolving to array of open positions
+   * @throws Error if request fails
+   */
+  async getPositions(agentId: string): Promise<Array<{ tokenAddress: string; [key: string]: unknown }>> {
+    const response = await apiClient.get(`/api/v1/agents/${agentId}/positions`);
+
+    if (!response.ok) {
+      const errorMessage = await extractErrorFromResponse(response);
+      throw new Error(errorMessage || 'Failed to fetch positions');
+    }
+
+    const data = await response.json();
+    return Array.isArray(data) ? data : data.positions || [];
+  }
+
   async getAgentBalanceHistory(
     agentId: string,
     walletAddress: string,


### PR DESCRIPTION
fix(auto-trade): respect market cap range and add 30s monitoring
- Enforce market cap guard on config-save immediate buys; defer to monitor when out of range
- Add fetchTokenMetricsBatch (Jupiter comma-separated query) to avoid rate limits
- Add AutoTradeMarketCapMonitor (30s) to open positions when market cap enters range
- Reconciliation skips tokens with bounds; monitor handles them exclusively
- Frontend: monitoring/active/waiting-for-range badges; getPositions + useAutoTradePositionTokens
- Logging: INFO when monitor runs and when token metrics are fetched
- Tests: reconciliation mock hasAutoTradeMarketCapBounds; token without bounds in config